### PR TITLE
Making this package as all in one react snippet package.

### DIFF
--- a/snippets/React (ES6).cson
+++ b/snippets/React (ES6).cson
@@ -51,7 +51,7 @@
 
     """
   'React ES6 Stateless Component':
-    'prefix': 'slc'
+    'prefix': 'rslc'
     'body': """
       import React from 'react';
 
@@ -79,6 +79,95 @@
       };
     """
 
+  #React Lifecycle Methods
+  'React ES6 componentWillMount() method':
+    'prefix': 'rcwm',
+    'body': """
+      componentWillMount() {
+        ${1}
+      }
+    """
+
+  'React ES6 componentDidMount() method':
+    'prefix': 'rcdm',
+    'body': """
+      componentDidMount() {
+        ${1}
+      }
+    """
+
+  'React ES6 componentWillReceiveProps() method':
+    'prefix': 'rcwrp',
+    'body': """
+      componentWillReceiveProps(nextProps) {
+        ${1}
+      }
+    """
+
+  'React ES6 shouldComponentUpdate() method':
+    'prefix': 'rscu',
+    'body': """
+      shouldComponentUpdate(nextProps, nextState) {
+        ${1}
+      }
+    """
+
+  'React ES6 componentWillUpdate() method':
+    'prefix': 'rcwu',
+    'body': """
+      componentWillUpdate(nextProps, nextState) {
+        ${1}
+      }
+    """
+
+  'React ES6 componentDidUpdate() method':
+    'prefix': 'rcdu',
+    'body': """
+      componentDidUpdate(prevProps, prevState) {
+        ${1}
+      }
+    """
+
+  'React ES6 componentWillUnmount() method':
+    'prefix': 'rcwun',
+    'body': """
+      componentWillUnmount() {
+        ${1}
+      }
+    """
+
+  #React Component APIs
+  'React setState':
+    'prefix': 'rss',
+    'body': """
+      this.setState({
+        ${1}: ${2},
+      });
+    """
+
+  'React setState - inline':
+    'prefix': 'rssi',
+    'body': """
+      this.setState({ ${1}: ${2} })
+    """
+
+  'React props':
+    'prefix': 'rprs',
+    'body': """
+      this.props.${1}
+    """
+
+  'React refs':
+    'prefix': 'rrfs',
+    'body': """
+      this.refs.${1}
+    """
+
+  'React findDOMNode()':
+    'prefix': 'rfdn',
+    'body': """
+      ReactDOM.findDOMNode({1})
+    """
 
   # PropType string
   'React PropType string':

--- a/snippets/React (ES6).cson
+++ b/snippets/React (ES6).cson
@@ -2,11 +2,15 @@
   'React ES6 Component':
     'prefix': 'rc'
     'body': """
-      import React, {PropTypes} from 'react';
+      import React from 'react';
 
       export default class ${1:MyComponent} extends React.Component {
         render() {
-          return (${2:<div>MyComponent</div>});
+          return (${2:
+            <div className="${1:MyComponent}">
+              MyComponent
+            </div>
+          });
         }
       }
 
@@ -17,7 +21,7 @@
   'React ES6 Component with Constructor':
     'prefix': 'rcc'
     'body': """
-      import React, {PropTypes} from 'react';
+      import React from 'react';
 
       export default class ${1:MyComponent} extends React.Component {
         constructor(props) {
@@ -25,7 +29,11 @@
         }
 
         render() {
-          return (${2:<div>MyComponent</div>});
+          return (${2:
+            <div className="${1:MyComponent}">
+              MyComponent
+            </div>
+          });
         }
       }
 
@@ -42,13 +50,17 @@
       }
 
     """
-  'React ES6 Functional Component':
-    'prefix': 'rfunc'
+  'React ES6 Stateless Component':
+    'prefix': 'slc'
     'body': """
-      import React, {PropTypes} from 'react';
+      import React from 'react';
 
       export const ${1} = (props) => {
-        return (${2:<div>MyComponent</div>});
+        return (${2:
+          <div className="${1:MyComponent}">
+            MyComponent
+          </div>
+        });
       }
 
       ${1}.propTypes = {

--- a/snippets/React (ES6).cson
+++ b/snippets/React (ES6).cson
@@ -2,7 +2,7 @@
   'React ES6 Component':
     'prefix': 'rc'
     'body': """
-      import React from 'react';
+      import { React, PropTypes } from 'react';
 
       export default class ${1:MyComponent} extends React.Component {
         render() {
@@ -21,7 +21,7 @@
   'React ES6 Component with Constructor':
     'prefix': 'rcc'
     'body': """
-      import React from 'react';
+      import { React, PropTypes } from 'react';
 
       export default class ${1:MyComponent} extends React.Component {
         constructor(props) {
@@ -53,7 +53,7 @@
   'React ES6 Stateless Component':
     'prefix': 'rslc'
     'body': """
-      import React from 'react';
+      import { React, PropTypes } from 'react';
 
       export const ${1} = (props) => {
         return (${2:


### PR DESCRIPTION
* Removing `{ Proptypes }`, as we've `*.propTypes = { }`.
* Ability to have the `class` name as the `className` for the top level element in that component.
* Renaming React functional component to React stateless component.
* Adding support for Component APIs.
* Adding support for Component lifecycle.