### PR TITLE
Update rfunc snippet to have name

### DIFF
--- a/snippets/React (ES6).cson
+++ b/snippets/React (ES6).cson
@@ -47,8 +47,10 @@
     'body': """
       import React, {PropTypes} from 'react';
 
-      export const ${1} = (props) => {
-        return (${2:<div>MyComponent</div>});
+      export default function ${1}(props) {
+        return (
+          ${2:<div>MyComponent</div>}
+        );
       }
 
       ${1}.propTypes = {


### PR DESCRIPTION
Using lambda makes debugging React SFCs harder because React can't infer the name of a component.
Plain old function is shorter and better for debugging.

Also updated return statement to be multi-line because most of the time render function would return
multi-line markup.

Also added `export default`. 